### PR TITLE
Implemented generateKey function that generates a BabyJubJub key pair…

### DIFF
--- a/clientlib/package.json
+++ b/clientlib/package.json
@@ -17,12 +17,12 @@
 		"ffjavascript": "^0.2.57"
 	},
 	"devDependencies": {
-		"chai": "^4.3.4",
+		"@nomicfoundation/hardhat-toolbox": "^2.0.1",
+		"@nomiclabs/hardhat-ethers": "^2.0.4",
+		"hardhat": "^2.12.4",
 		"circom_tester": "0.0.19",
 		"circomlibjs": "0.1.7",
-		"mocha": "^9.1.2",
-		"hardhat": "^2.12.4",
-		"@nomicfoundation/hardhat-toolbox": "^2.0.1",
-		"@nomiclabs/hardhat-ethers": "^2.0.4"
+		"chai": "^4.3.4",
+		"mocha": "^9.1.2"
 	}
 }

--- a/clientlib/src/anonvote.js
+++ b/clientlib/src/anonvote.js
@@ -3,7 +3,7 @@ const { buildPoseidonReference, buildEddsa, buildBabyjub } = require(
 	"circomlibjs",
 );
 
-const { utils } = require('ffjavascript');
+const { utils: ffutils } = require('ffjavascript');
 
 const {ethers} = require("ethers");
 
@@ -52,11 +52,7 @@ class AnonVote {
 		const text = "ANONVOTE KEY GENERATION SECRET";
 		const signature = await signer.signMessage(text);
 
-		const privateKey = this.poseidon([signature]);
-		// Make sure that the private key has the correct format of 32 bytes
-		if (privateKey.length !== 32) {
-			throw new Error("Private key has wrong length");
-		}
+		const privateKey = ethers.utils.keccak256(signature);
 
 		// Compute the public key by hashing the private key to the BabyJubJub curve
 		const publicKey = this.eddsa.prv2pub(privateKey)
@@ -67,8 +63,8 @@ class AnonVote {
 
 
 		// Compute the compressed public key
-		const compressedPublicKey = utils.leBuff2int(this.babyjub.packPoint(publicKey))
-		this.compressedPublicKey = ethers.utils.hexZeroPad(`0x${compressedPublicKey.toString(16)}`, 32).slice(2);
+		const compressedPublicKey = ffutils.leBuff2int(this.babyjub.packPoint(publicKey))
+		this.compressedPublicKey = ethers.utils.hexZeroPad(`0x${compressedPublicKey.toString(16)}`, 32);
 
 		return {privateKey: this.privateKey, publicKey: this.publicKey, compressedPublicKey: this.compressedPublicKey };
 	}

--- a/clientlib/test/anonvote.test.js
+++ b/clientlib/test/anonvote.test.js
@@ -59,12 +59,12 @@ describe("ClientLib", function () {
 
 			const {privateKey, publicKey, compressedPublicKey } = await av.generateKey(signer);
 
-			// Check that the private key is 32 bytes long
-			expect(privateKey.length).to.equal(32);
+			// Check that the private key is 32 bytes long hex string (0x prefix + 64 hex chars)
+			expect(privateKey).to.match(/^0x[0-9a-fA-F]{64}$/);
 			// Check that the public key is not null
 			expect(publicKey).to.not.be.null;
-			// Check that the compressed public key is not null
-			expect(compressedPublicKey).to.not.be.null;
+			// Check that the compressed public key is a 32 bytes long hex string (0x prefix + 64 hex chars)
+			expect(compressedPublicKey).to.match(/^0x[0-9a-fA-F]{64}$/);
 
 		});
 	});


### PR DESCRIPTION
Implemented BabyJubJub key pair generation.

To confirm:
- [ ] do we need the raw or the compressed public key?

Note:
- Testing is very limited with no way to confirm if the correct keys are generated

Resolved #1 