### PR TITLE
Feature/clientlib export import census

### DIFF
--- a/clientlib/src/census.js
+++ b/clientlib/src/census.js
@@ -1,25 +1,33 @@
-import { newMemEmptyTrie, buildPoseidonReference } from "circomlibjs";
+import { newMemEmptyTrie, buildPoseidonReference, buildBabyjub } from "circomlibjs";
+import { utils as ffutils} from 'ffjavascript';
 
 async function buildCensus(nLevels) {
 	const poseidon = await buildPoseidonReference();
+	const babyjub = await buildBabyjub();
 	const tree = await newMemEmptyTrie()
-	return new Census(tree, poseidon, nLevels);
+	return new Census(tree, poseidon, babyjub, nLevels);
 }
 
 class Census {
-	constructor(tree, poseidon, nLevels) {
+	constructor(tree, poseidon, babyjub, nLevels) {
 		this.poseidon = poseidon;
+		this.babyjub = babyjub;
 		this.F = this.poseidon.F;
 		this.nLevels = nLevels;
 		this.tree = tree;
+		this.publicKeys = [];
+		this.lastIndex = 0
 	}
 
 	async addKeys(publicKeys) {
 		for (let i=0; i<publicKeys.length; i++) {
+			this.publicKeys.push(publicKeys[i]);
+
 			const leafValue = this.poseidon([publicKeys[i][0], publicKeys[i][1], "1"]);
 
-			await this.tree.insert(i, leafValue);
+			await this.tree.insert(this.lastIndex + i, leafValue);
 		}
+		this.lastIndex += publicKeys.length;
 	}
 
 	// generateProof generates the proof from the local tree
@@ -44,6 +52,26 @@ class Census {
 		return this.F.toObject(this.tree.root).toString();
 	}
 
+	export() {
+		let compPubKs = [];
+		for (let i=0; i<this.publicKeys.length; i++) {
+			let compPubK = ffutils.leBuff2int(this.babyjub.packPoint(this.publicKeys[i]));
+			compPubKs.push(compPubK.toString());
+		}
+		return JSON.stringify(compPubKs);
+	}
+
+	async import(jsonData) {
+		let compPubKs = JSON.parse(jsonData);
+		let pubKs = [];
+		for (let i=0; i<compPubKs.length; i++) {
+			let compPubK = ffutils.leInt2Buff(BigInt(compPubKs[i]));
+			let pubK = this.babyjub.unpackPoint(compPubK);
+			pubKs.push(pubK);
+		}
+		await this.addKeys(pubKs);
+	}
 }
+
 
 export { Census, buildCensus };

--- a/clientlib/test/census.test.js
+++ b/clientlib/test/census.test.js
@@ -40,6 +40,35 @@ describe("Census generation tests", function () {
 		let proof = await census.generateProof(0);
 		assert(proof.index == 0);
 		const leafValue = av.poseidon([publicKeys[0][0], publicKeys[0][1], "1"]);
-		assert(proof.value, av.F.toObject(leafValue).toString());
+		expect(proof.value).to.equal(av.F.toObject(leafValue).toString());
+	});
+	it("export & import census", async () => {
+		const av = await buildAnonVote(chainID, nLevels, null);
+		const census = await buildCensus(nLevels);
+		
+		// simulate key generation
+		const privateKey = fromHexString(
+			"0001020304050607080900010203040506070809000102030405060708090000",
+		);
+		const publicKey = av.eddsa.prv2pub(privateKey);
+		
+		// gen other pubKeys
+		let publicKeys = [publicKey];
+		for (let i=1; i<10; i++) {
+			const privateKey = fromHexString(
+				"000102030405060708090001020304050607080900010203040506070809000"+i,
+			);
+			const publicKey = av.eddsa.prv2pub(privateKey);
+			publicKeys.push(publicKey);
+		}
+		
+		await census.addKeys(publicKeys);
+
+		let exportedJSON = census.export();
+
+		const census2 = await buildCensus(nLevels);
+		await census2.import(exportedJSON);
+
+		expect(census2.root()).to.equal(census.root());
 	});
 });


### PR DESCRIPTION
resolves #50 

Exports the census with the publicKeys as strings of decimal representations of the compressed public keys. In a future iteration it can be changed to export in hexadecimal representation.