### PR TITLE
clientlib: return tx.hash when sending a tx

### DIFF
--- a/clientlib/src/anonvote.js
+++ b/clientlib/src/anonvote.js
@@ -166,6 +166,10 @@ class AnonVote {
 		};
 	}
 
+	async getLastProcessID() {
+		return await this.anonVoting.lastProcessID();
+	}
+
 	// Method to get all the processes in the AnonVoting contract
 	async getProcesses() {
 		if (!this.web3gw) {
@@ -194,13 +198,8 @@ class AnonVote {
 
 		const anonVotingWithSigner = this.anonVoting.connect(signer);
 
-
-
-		await anonVotingWithSigner.newProcess(topic, censusIpfsHash, censusRoot, startBlock, endBlock, minMajority, minTurnout);
-
-
-		// Return the created processID
-		return  await this.anonVoting.lastProcessID();
+		let tx = await anonVotingWithSigner.newProcess(topic, censusIpfsHash, censusRoot, startBlock, endBlock, minMajority, minTurnout);
+		return  tx.hash;
 	}
 
 	getMerkleProof() {}
@@ -245,9 +244,10 @@ class AnonVote {
 		if (!isValid) throw new Error("The generated proof is not valid");
 
 		// call contract vote method sending the proof
-		await anonVotingWithSigner.vote(processID, voteBool,
+		let tx = await anonVotingWithSigner.vote(processID, voteBool,
 			proofAndPI.publicInputs.nullifier, proofAndPI.proof[0],
 			proofAndPI.proof[1], proofAndPI.proof[2], {gasLimit: gasLimit});
+		return  tx.hash;
 	}
 
 	// Method to check if a voter has already voted in a process

--- a/clientlib/test/anonvote.test.js
+++ b/clientlib/test/anonvote.test.js
@@ -270,7 +270,8 @@ describe("ClientLib", function () {
 			const signer = (await ethers.getSigners())[0];
 
 			// Create the process
-			const processID = await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			const processID = await av.getLastProcessID();
 
 			return {av, processID, signer, web3gw, nLevels, topic, censusRoot, startBlock, endBlock, minTurnout, minMajority };
 		}
@@ -292,7 +293,8 @@ describe("ClientLib", function () {
 			const signer = (await ethers.getSigners())[0];
 
 			// Create the process
-			const processID = await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			const processID = await av.getLastProcessID();
 			expect(processID).to.equal(1);
 
 			// // Get the process that was just created
@@ -328,7 +330,8 @@ describe("ClientLib", function () {
 			const signer = (await ethers.getSigners())[0];
 
 			// Create the process
-			const processID1 = await av.newProcess(topicOne, censusIPFSHashOne, censusRootOne, startBlockOne, endBlockOne, minTurnoutOne, minMajorityOne, signer);
+			await av.newProcess(topicOne, censusIPFSHashOne, censusRootOne, startBlockOne, endBlockOne, minTurnoutOne, minMajorityOne, signer);
+			const processID1 = await av.getLastProcessID();
 			expect(processID1).to.equal(1);
 
 			// Set the parameters for the second process
@@ -342,7 +345,8 @@ describe("ClientLib", function () {
 
 
 			// Create a second process
-			const processID2 = await av.newProcess(topicTwo, censusIPFSHashTwo, censusRootTwo, startBlockTwo, endBlockTwo, minTurnoutTwo, minMajorityTwo, signer);
+			await av.newProcess(topicTwo, censusIPFSHashTwo, censusRootTwo, startBlockTwo, endBlockTwo, minTurnoutTwo, minMajorityTwo, signer);
+			const processID2 = await av.getLastProcessID();
 			expect(processID2).to.equal(2);
 
 
@@ -434,7 +438,8 @@ describe("ClientLib", function () {
 			const signer = (await ethers.getSigners())[0];
 
 			// Create the process
-			const processID = await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			await av.newProcess(topic, censusIPFSHash, censusRoot, startBlock, endBlock, minTurnout, minMajority, signer);
+			const processID = await av.getLastProcessID();
 			expect(processID).to.equal(1);
 
 			// Skip to the start of the process


### PR DESCRIPTION
In newProcess method we were returning the lastProcessID when the tx has not been already included in the chain. Now it returns the tx hash so the user can track when is minted. Same for cast vote method.